### PR TITLE
Feat check every n loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ console.log('All finished');
 …to this:
 
 ```js
-let i = 0;
 var _LP = Date.now();
 while (true) {
   if (Date.now() - _LP > 100)
@@ -76,7 +75,8 @@ doc.close();
 // code now runs, and if there's an infinite loop, it's cleanly exited
 ```
 
-### Optional Second Argument 
+### Optional Second Argument
+
 In the above implementation, when code transformed by loop-protect contains an infinite loop, the loop is cleanly exited with a `break` statement, and any code after the loop is executed normally. See [example](https://github.com/jsbin/loop-protect#example). 
 
 But what if you want to log an error to the console to warn the user, or throw an error instead, to stop execution when an infinite loop is encountered? The `protect` function takes an optional second argument which can handle both behaviors. 
@@ -116,6 +116,30 @@ console.log('All finished'); // does not execute
 
 // Error: Bad loop on line 1
 ```
+
+### Optional Third Argument
+
+If your code involves a large, but finite, number of loops, you can use the third
+argument, `iterations`, to improve performance.  `Date.now()` is a relatively expensive
+operation, and it will only be checked once every `iterations` passes through a loop.
+
+With `iterations = 100` the initial code becomes
+
+```js
+var _LPC = 1;
+var _LP = Date.now();
+while (true) {
+  if (_LPC++ % 100 === 0 && Date.now() - _LP > 100)
+    break;
+
+  doSomething();
+}
+
+console.log('All finished');
+```
+
+skipping the first `Date.now()` call and only checking if the loop has been
+running too long once every 100 passes.
 
 ## Contributors
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const generateBefore = (t, id) =>
+const generateStartVar = (t, id) =>
   t.variableDeclaration('var', [
     t.variableDeclarator(
       id,
@@ -9,35 +9,66 @@ const generateBefore = (t, id) =>
     ),
   ]);
 
-const generateInside = ({ t, id, line, ch, timeout, extra } = {}) => {
-  return t.ifStatement(
-    t.binaryExpression(
-      '>',
-      t.binaryExpression(
-        '-',
-        t.callExpression(
-          t.memberExpression(t.identifier('Date'), t.identifier('now')),
-          []
-        ),
-        id
-      ),
-      t.numericLiteral(timeout)
+const generateCounter = (t, id) =>
+  t.variableDeclaration('var', [
+    t.variableDeclarator(
+      id,
+      t.numericLiteral(1)
     ),
+  ]);
+
+const generateDateComparison = ({ t, id, line, ch, timeout, extra } = {}) => 
+  t.ifStatement(
+    generateTimeoutElapsed({t, id, timeout}),
     extra
-      ? t.blockStatement([
-          t.expressionStatement(
-            t.callExpression(extra, [
-              t.numericLiteral(line),
-              t.numericLiteral(ch),
-            ])
-          ),
-          t.breakStatement(),
-        ])
+      ? generateExtra({t, extra, line, ch})
       : t.breakStatement()
   );
-};
 
-const protect = (t, timeout, extra) => path => {
+const generateTimeoutElapsed = ({t, id, timeout} = {}) => 
+  t.binaryExpression(
+    '>',
+    t.binaryExpression(
+      '-',
+      t.callExpression(
+        t.memberExpression(t.identifier('Date'), t.identifier('now')),
+        []
+      ),
+      id
+    ),
+    t.numericLiteral(timeout)
+  );
+
+const generateExtra = ({t, extra, line, ch} = {}) =>
+  t.blockStatement([
+    t.expressionStatement(
+      t.callExpression(extra, [
+        t.numericLiteral(line),
+        t.numericLiteral(ch),
+      ])
+    ),
+    t.breakStatement(),
+  ]);
+
+const generateInside = ({ t, id, counterId, line, ch, timeout, extra, iterations } = {}) => 
+  iterations ? 
+  t.ifStatement(
+    t.logicalExpression('&&', 
+      t.binaryExpression('===',
+        t.binaryExpression('%', 
+          t.updateExpression('++', counterId),
+          t.numericLiteral(iterations)
+        ),
+        t.numericLiteral(0)
+      ),
+      generateTimeoutElapsed({t, id, timeout})
+    ),
+      extra
+        ? generateExtra({t, extra, line, ch})
+        : t.breakStatement()
+  ) : generateDateComparison({ t, id, line, ch, timeout, extra });
+
+const protect = (t, timeout, extra, iterations) => path => {
   if (!path.node.loc) {
     // I don't really know _how_ we get into this state
     // but https://jsbin.com/mipesawapi/1/ triggers it
@@ -46,14 +77,18 @@ const protect = (t, timeout, extra) => path => {
     return;
   }
   const id = path.scope.generateUidIdentifier('LP');
-  const before = generateBefore(t, id);
+  const counterId = path.scope.generateUidIdentifier('LPC');
+  const counterVar = generateCounter(t, counterId);
+  const startVar = generateStartVar(t, id);
   const inside = generateInside({
     t,
     id,
+    counterId,
     line: path.node.loc.start.line,
     ch: path.node.loc.start.column,
     timeout,
     extra,
+    iterations
   });
   const body = path.get('body');
 
@@ -61,11 +96,12 @@ const protect = (t, timeout, extra) => path => {
   if (!t.isBlockStatement(body)) {
     body.replaceWith(t.blockStatement([body.node]));
   }
-  path.insertBefore(before);
+  path.insertBefore(counterVar);
+  path.insertBefore(startVar);
   body.unshiftContainer('body', inside);
 };
 
-module.exports = (timeout = 100, extra = null) => {
+module.exports = (timeout = 100, extra = null, iterations = null) => {
   if (typeof extra === 'string') {
     const string = extra;
     extra = `() => console.error("${string.replace(/"/g, '\\"')}")`;
@@ -91,9 +127,9 @@ module.exports = (timeout = 100, extra = null) => {
 
     return {
       visitor: {
-        WhileStatement: protect(t, timeout, callback),
-        ForStatement: protect(t, timeout, callback),
-        DoWhileStatement: protect(t, timeout, callback),
+        WhileStatement: protect(t, timeout, callback, iterations),
+        ForStatement: protect(t, timeout, callback, iterations),
+        DoWhileStatement: protect(t, timeout, callback, iterations),
       },
     };
   };

--- a/test/every-n-loop.test.js
+++ b/test/every-n-loop.test.js
@@ -1,0 +1,102 @@
+/* eslint-env node, jest */
+const Babel = require("@babel/standalone");
+
+const code = `let i = 0; while (true) { i++; }; done(i)`;
+
+let done = jest.fn();
+
+beforeEach(() => {
+  done = jest.fn();
+});
+
+const transform = id => code =>
+  Babel.transform(new Function(code).toString(), {
+    plugins: [id]
+  }).code; // eslint-disable-line no-new-func
+
+const run = code => {
+  // console.log(code);
+  eval(`(${code})()`); // eslint-disable-line no-eval
+};
+
+test("10 iterations", () => {
+  const id = "lp1";
+  Babel.registerPlugin(id, require("../lib")(100, null, 10));
+  const after = transform(id)(code);
+  run(after);
+  expect(done).toBeCalledWith(expect.any(Number));
+});
+
+test("anonymous callback and 10 iterations", () => {
+  const id = "lp2";
+  Babel.registerPlugin(
+    id,
+    require("../lib")(100, line => done(`line: ${line}`), 10)
+  );
+  const after = transform(id)(code);
+  run(after);
+  expect(done).toHaveBeenCalledWith("line: 3");
+});
+
+test("arrow function callback and 10 iterations", () => {
+  const id = "lp3";
+  const callback = line => done(`lp3: ${line}`);
+
+  Babel.registerPlugin(id, require("../lib")(100, callback, 10));
+  const after = transform(id)(code);
+  run(after);
+  expect(done).toHaveBeenCalledWith(`${id}: 3`);
+});
+
+test("named function callback and 10 iterations", () => {
+  const id = "lp4";
+  function callback(line) {
+    done(`lp4: ${line}`);
+  }
+
+  Babel.registerPlugin(id, require("../lib")(100, callback, 10));
+  const after = transform(id)(code);
+  run(after);
+  expect(done).toHaveBeenCalledWith(`${id}: 3`);
+});
+
+test("named function callback and 1000 iterations", () => {
+  const id = "lp5";
+  const iterations = 1000;
+  function callback(line) {
+    done(`lp5: ${line}`);
+  }
+
+  Babel.registerPlugin(id, require("../lib")(100, callback, iterations));
+  const after = transform(id)(code);
+  run(after);
+  expect(done).toHaveBeenCalledWith(`${id}: 3`);
+  // iteration counter starts at 1, so the first pass through the loop does not
+  // check the date, since we have no reason to believe it is infinite at the
+  // start
+  expect(done.mock.calls[1][0] % iterations).toBe(999);
+});
+
+test("no callback and 10000 iterations", () => {
+  const id = "lp6";
+  const iterations = 10000;
+
+  Babel.registerPlugin(id, require("../lib")(100, null, iterations));
+  const after = transform(id)(code);
+  run(after);
+  expect(done).toBeCalledWith(expect.any(Number));
+  expect(done.mock.calls[0][0] % iterations).toBe(9999);
+});
+
+test("two loops", () => {
+  const id = "lp7";
+  const iterations = 100;
+  const twoLoops = `let i = 0; while (i < 5) { i++; }; while (true) { i++; }; done(i)`
+
+  Babel.registerPlugin(id, require("../lib")(100, null, iterations));
+  const after = transform(id)(twoLoops);
+  run(after);
+  expect(done).toBeCalledWith(expect.any(Number));
+  // (5 + 99) % 100 == 4
+  expect(done.mock.calls[0][0] % iterations).toBe(4);
+});


### PR DESCRIPTION
Adds a 3rd argument, iterations, that restricts the date checking to once every iterations loops.  This allows code with tight loops to avoid expensive Date.now() calls every loop, to improve performance.