### PR TITLE
fix: handle non-standard toString

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ const generateCounter = (t, id) =>
     ),
   ]);
 
-const generateDateComparison = ({ t, id, line, ch, timeout, extra } = {}) => 
+const generateDateComparison = ({ t, id, line, ch, timeout, extra } = {}) =>
   t.ifStatement(
     generateTimeoutElapsed({t, id, timeout}),
     extra
@@ -25,7 +25,7 @@ const generateDateComparison = ({ t, id, line, ch, timeout, extra } = {}) =>
       : t.breakStatement()
   );
 
-const generateTimeoutElapsed = ({t, id, timeout} = {}) => 
+const generateTimeoutElapsed = ({t, id, timeout} = {}) =>
   t.binaryExpression(
     '>',
     t.binaryExpression(
@@ -50,12 +50,12 @@ const generateExtra = ({t, extra, line, ch} = {}) =>
     t.breakStatement(),
   ]);
 
-const generateInside = ({ t, id, counterId, line, ch, timeout, extra, iterations } = {}) => 
-  iterations ? 
+const generateInside = ({ t, id, counterId, line, ch, timeout, extra, iterations } = {}) =>
+  iterations ?
   t.ifStatement(
-    t.logicalExpression('&&', 
+    t.logicalExpression('&&',
       t.binaryExpression('===',
-        t.binaryExpression('%', 
+        t.binaryExpression('%',
           t.updateExpression('++', counterId),
           t.numericLiteral(iterations)
         ),
@@ -102,15 +102,16 @@ const protect = (t, timeout, extra, iterations) => path => {
 };
 
 module.exports = (timeout = 100, extra = null, iterations = null) => {
+  const anonRegex = /^function\s*\(/;
   if (typeof extra === 'string') {
     const string = extra;
     extra = `() => console.error("${string.replace(/"/g, '\\"')}")`;
   } else if (extra !== null) {
     extra = extra.toString();
-    if (extra.startsWith('function (')) {
+    if (extra.match(anonRegex)) {
       // fix anonymous functions as they'll cause
       // the callback transform to blow up
-      extra = extra.replace(/^function \(/, 'function callback(');
+      extra = extra.replace(anonRegex, 'function callback(');
     }
   }
 

--- a/test/callback.test.js
+++ b/test/callback.test.js
@@ -59,3 +59,18 @@ test('named function callback', () => {
   run(after);
   expect(done).toHaveBeenCalledWith(`${id}: 3`);
 });
+
+/* this depends on how Function.prototype.toString() is implemented
+   and so is difficult to test reliably.
+*/
+test('anonymous function callback', () => {
+  const id = 'lp5';
+  var anon = function (line) { done(`lp5, line: ${line}`) }
+  Babel.registerPlugin(
+    id,
+    require('../lib')(100, anon)
+  );
+  const after = transform(id)(code);
+  run(after);
+  expect(done).toHaveBeenCalledWith(`${id}, line: 3`);
+});


### PR DESCRIPTION
Whitespace in Function.prototype.toString is not uniquely specified so it should not be relied on when checking if a function is anonymous or not.  This change mitigates that by testing for an arbitrary number of spaces.  

This was motivated by a weird situation where the built version of a Gatsby site removed the names of functions and their `toString` resulted in `function(`, not `function (` and loop-protect failed to convert them.